### PR TITLE
Updates for help, hangman, mathrun and wordrun

### DIFF
--- a/FaustBot/Modules/BlockObserver.py
+++ b/FaustBot/Modules/BlockObserver.py
@@ -10,11 +10,11 @@ from FaustBot.Model.BlockedUsers import BlockProvider
 class BlockObserver(PrivMsgObserverPrototype):
     @staticmethod
     def cmd():
-        return [""]
+        return None
 
     @staticmethod
     def help():
-        return ""
+        return None
 
     def update_on_priv_msg(self, data, connection: Connection):
         if not self._is_idented_mod(data, connection):

--- a/FaustBot/Modules/HelpObserver.py
+++ b/FaustBot/Modules/HelpObserver.py
@@ -1,3 +1,4 @@
+from types import NoneType
 from FaustBot.Communication import Connection
 from FaustBot.Modules.PrivMsgObserverPrototype import PrivMsgObserverPrototype
 
@@ -9,24 +10,52 @@ class HelpObserver(PrivMsgObserverPrototype):
 
     @staticmethod
     def help():
-        return ".help - zeigt Hilftexte aller Module an"
+        return ".help <Befehl> - zeigt Hilftexte zu <Befehl> an. Für eine Liste aller verfügbaren Befehle: .help all"
 
     def update_on_priv_msg(self, data, connection: Connection):
         msg = data["message"]
+        command = ""
         if not msg.startswith(".help"):
             return
+        if len(msg.split(' ')) > 1:
+            command = msg.split(' ')[1]
+            if command == 'all':
+                self.show_available_commands(data, connection)
+            else:    
+                if not command.startswith("."):
+                    command = '.' + command
+                self.show_help_for_command(command, data, connection)
+        else:
+            connection.send_back(self.help(), data)
 
+    def collect_commands(self, connection):
+        all_cmd = []
+        for observer in connection.priv_msg_observable.get_observer():
+            cmds = observer.cmd()
+            if cmds is not None:
+                all_cmd.extend(cmds)
+        print(all_cmd)
+        return all_cmd
+
+    def show_available_commands(self, data, connection):
         if data["channel"] == connection.details.get_channel():
             all_cmd = []
-            for observer in connection.priv_msg_observable.get_observer():
-                cmds = observer.cmd()
-                if cmds is not None:
-                    all_cmd.extend(cmds)
+            all_cmd = self.collect_commands(connection)
             msg = ", ".join(all_cmd)
-            msg = "Bekannte Befehle: " + msg + ". Für Details per Query .help ."
+            msg = "Bekannte Befehle: " + msg
             connection.send_back(msg, data)
         else:
             all_help = [m.help() for m in connection.priv_msg_observable.get_observer()]
             for help_msg in all_help:
                 if help_msg is not None:
                     connection.send_back(help_msg, data)
+
+    def show_help_for_command(self, command, data, connection):
+        for observer in connection.priv_msg_observable.get_observer():
+            if observer.cmd() is not None:
+                if command in observer.cmd():
+                    print(observer.help())
+                    connection.send_back(observer.help(), data)
+        
+
+       

--- a/FaustBot/Modules/MathRunObserver.py
+++ b/FaustBot/Modules/MathRunObserver.py
@@ -6,11 +6,11 @@ from time import sleep
 class MathRunObserver(PrivMsgObserverPrototype):
     @staticmethod
     def cmd():
-        return ['.s', '.startMath', '.stopMath']
+        return ['.s', '.startmath', '.stopmath']
 
     @staticmethod
     def help():
-        return 'startMath startet eine Reihe von Aufgaben. StopMath beendet sie.'
+        return '.startmath startet eine Reihe von Aufgaben. .stopmath beendet sie. Lösungen mit ".s Lösung" eingeben.'
 
     def __init__(self):
         super().__init__()
@@ -23,7 +23,7 @@ class MathRunObserver(PrivMsgObserverPrototype):
     def update_on_priv_msg(self, data, connection: Connection):
         if data['message'].find('.s ') != -1 :
             self.solution(data, connection)
-        if data['message'].find('.startMath') != -1:
+        if data['message'].find('.startmath') != -1:
             self.start_math(data, connection)
 
     def solution(self, data, connection):

--- a/FaustBot/Modules/MathRunObserver.py
+++ b/FaustBot/Modules/MathRunObserver.py
@@ -10,7 +10,7 @@ class MathRunObserver(PrivMsgObserverPrototype):
 
     @staticmethod
     def help():
-        return '.startmath startet eine Reihe von Aufgaben. .stopmath beendet sie. Lösungen mit ".s Lösung" eingeben.'
+        return '".startmath" startet eine Reihe von Aufgaben. ".stopmath" beendet sie. Lösungen mit ".s Lösung" eingeben.'
 
     def __init__(self):
         super().__init__()
@@ -21,16 +21,18 @@ class MathRunObserver(PrivMsgObserverPrototype):
         self.oldSolution = 0
 
     def update_on_priv_msg(self, data, connection: Connection):
-        if data['message'].find('.s ') != -1 :
+        if data['message'].startswith('.s ') and not data['message'].startswith('.startmath') and not data['message'].startswith('.stopmath'):
             self.solution(data, connection)
-        if data['message'].find('.startmath') != -1:
+        if data['message'].startswith('.startmath'):
             self.start_math(data, connection)
+        if data['message'].startswith('.stopmath'):
+            self.stop_math(data, connection)
 
     def solution(self, data, connection):
         nick = data["nick"]
         solutionByPlayer = data['message'].split()[1]
         if solutionByPlayer is None:
-            connection.send_back("Sorry du hast keine Lösung angegeben " + nick, data)
+            connection.send_back("Du hast keine Lösung angegeben " + nick, data)
             return
         if solutionByPlayer == str(self.solutionForGame):
             connection.send_channel("Korrekte Lösung " + nick)
@@ -63,9 +65,13 @@ class MathRunObserver(PrivMsgObserverPrototype):
             self.stop_Timer(data, connection)
 
     def stop_math(self, data, connection):
+        
         for player in self.players.keys():
-            connection.send_channel(player + " hat\t" + str(self.players[player]) + "\t Punkte")
-        connection.send_channel("Spiel beendet")
+            if self.players[player] == 1:
+                connection.send_channel(player + " hat\t" + str(self.players[player]) + "\tPunkt")
+            else:
+                connection.send_channel(player + " hat\t" + str(self.players[player]) + "\tPunkte")
+        connection.send_channel("Mathrun beendet")
         self.players = {}
         self.solutionForGame = 0
         self.type = 0
@@ -73,4 +79,5 @@ class MathRunObserver(PrivMsgObserverPrototype):
 
     def stop_Timer(self, data, connection):
         sleep(120)
-        self.stop_math(data, connection)
+        if self.running:
+            self.stop_math(data, connection)

--- a/FaustBot/Modules/WordRunObserver.py
+++ b/FaustBot/Modules/WordRunObserver.py
@@ -8,11 +8,11 @@ from time import sleep
 class WordRunObserver(PrivMsgObserverPrototype):
     @staticmethod
     def cmd():
-        return ['.a', '.add', '.begin', '.end']
+        return ['.a', '.add', '.begin', '.end', '.wordrun']
 
     @staticmethod
     def help():
-        return 'wordrun game'
+        return 'Wordrun Spiel. Starten mit ".begin <Silbe>" oder ".end <Silbe>". Antwort hinzufügen mit ".a <Antwort>" oder ".add <Antwort>" Mehr Details mit ".wordrun" abfragen.'
 
     def __init__(self):
         super().__init__()
@@ -26,13 +26,15 @@ class WordRunObserver(PrivMsgObserverPrototype):
         self.syllable = ""
 
     def update_on_priv_msg(self, data, connection: Connection):
-        if data['message'].find('.a ') != -1 or data['message'].find('.add ') != -1:
+          if data['message'].startswith('.a ') or data['message'].startswith('.add '):
             self.add(data, connection)
-        if data['message'].find('.begin ') != -1:
-            self.begin_word(data, connection)
-        if data['message'].find('.end ') != -1:
-            self.end_word(data, connection)
-
+            if data['message'].startswith('.begin '):
+                self.begin_word(data, connection)
+            if data['message'].startswith('.end '):
+                self.end_word(data, connection)
+            if data['message'].startswith('.wordrun'):
+                self.rules(data, connection)
+   
     def add(self, data, connection):
         if self.gamestatus == 0:
             connection.send_channel("Es läuft derzeit kein Wordrun, bitte einen neuen mit .begin <Silbe> oder .end <Silbe> erstellen!")
@@ -95,3 +97,15 @@ class WordRunObserver(PrivMsgObserverPrototype):
         connection.send_channel(s)
         self.gamestatus = 0
         self.player = {}
+
+    def rules(self, data, connection):
+        if data['channel'] == connection.details.get_channel():
+            connection.send_back("Spielregeln bitte im Query (Privatchat) mit dem Bot abfragen", data)
+            return
+        connection.send_back('Wordrun Spiel: So viele Wörter wie möglich finden, die mit der vorgegebenen Silbe anfangen oder aufhören.', data)
+        connection.send_back('Spiel starten mit ".begin <Silbe>", um ein Spiel zu starten, bei dem die Antworten mit <Silbe> anfangen müssen.', data)
+        connection.send_back('Spiel starten mit ".end <Silbe>", um ein Spiel zu starten, bei dem die Antworten mit <Silbe> enden müssen.', data)
+        connection.send_back('Antwort hinzufügen mit ".a <Antwort>" oder ".add <Antwort>"', data)
+        connection.send_back('Es können auch mehrere Antworten in einer Zeile angegeben werden', data)
+        connection.send_back('Das Spiel dauert 3 Minuten. Für jede gültige Antwort gibt es 1 Punkt.', data)
+


### PR DESCRIPTION
.help <command> now shows help message for a specified module; requesting full list at once is still possible
messages must start with a command, otherwise the command is being ignored
updated some help messages, added rules to wordrun
implemented stopmath and changed commands in mathrun to lowercase
implemented confirmation to resetscore in hangman
excluded all available commands from being accepted as .word in hangman
removed empty command in blockobserver

